### PR TITLE
Improve time to show ads

### DIFF
--- a/External Cocos Helper Android Frameworks/Frameworks/AdMob/AdMobAds.java
+++ b/External Cocos Helper Android Frameworks/Frameworks/AdMob/AdMobAds.java
@@ -28,6 +28,10 @@ public class AdMobAds extends Framework
 	
 	private static AdView top_banner_adView;
 	private static AdView bottom_banner_adView;
+	private static boolean top_banner_adView_request_sended = false;
+	private static boolean bottom_banner_adView_request_sended = false;
+	private static AdRequest top_banner_adView_request;
+	private static AdRequest bottom_banner_adView_request;
 	private InterstitialAd interstitial;
 
 	FrameLayout.LayoutParams top_adParams;
@@ -63,7 +67,7 @@ public class AdMobAds extends Framework
 		top_banner_adView.setAdSize(AdSize.BANNER);
 		top_banner_adView.setAdUnitId(banner_id_top);
 
-		AdRequest adRequest = new AdRequest.Builder()
+		top_banner_adView_request = new AdRequest.Builder()
 		.addTestDevice(AdRequest.DEVICE_ID_EMULATOR)
 		.addTestDevice("HASH_DEVICE_ID")
 		.addTestDevice(test_device_id)
@@ -71,7 +75,6 @@ public class AdMobAds extends Framework
 		
 		top_adParams = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT, android.view.Gravity.TOP|android.view.Gravity.CENTER_HORIZONTAL);
 
-		top_banner_adView.loadAd(adRequest);
 		top_banner_adView.setBackgroundColor(Color.BLACK);
 		top_banner_adView.setBackgroundColor(0);
 		
@@ -82,7 +85,7 @@ public class AdMobAds extends Framework
 		bottom_banner_adView.setAdSize(AdSize.BANNER);
 		bottom_banner_adView.setAdUnitId(banner_id_bottom);
 
-		AdRequest adRequest1 = new AdRequest.Builder()
+		bottom_banner_adView_request = new AdRequest.Builder()
 		.addTestDevice(AdRequest.DEVICE_ID_EMULATOR)
 		.addTestDevice("HASH_DEVICE_ID")
 		.addTestDevice(test_device_id)
@@ -90,7 +93,6 @@ public class AdMobAds extends Framework
 		
 		bottom_adParams = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT, android.view.Gravity.BOTTOM|android.view.Gravity.CENTER_HORIZONTAL);
 
-		bottom_banner_adView.loadAd(adRequest1);
 		bottom_banner_adView.setBackgroundColor(Color.BLACK);
 		bottom_banner_adView.setBackgroundColor(0);
 		
@@ -174,10 +176,14 @@ public class AdMobAds extends Framework
 
 		     @Override
 		     public void run()
-		     {  
+		     {
+		     		if (!top_banner_adView_request_sended) {
+			     		top_banner_adView.loadAd(top_banner_adView_request);
+			     		top_banner_adView_request_sended = true;
+		     		}
 		    	 	if (!top_banner_adView.isEnabled())
 		    	 		top_banner_adView.setEnabled(true);
-		    	 	 if (top_banner_adView.getVisibility() == 4 )
+		    	 	if (top_banner_adView.getVisibility() == 4 )
 		    	 		top_banner_adView.setVisibility(View.VISIBLE); 
 		     }
 	     });
@@ -201,7 +207,11 @@ public class AdMobAds extends Framework
 
 				     @Override
 				     public void run()
-				     { 	
+				     {
+				     	if (!top_banner_adView_request_sended) {
+				     		top_banner_adView.loadAd(top_banner_adView_request);
+				     		top_banner_adView_request_sended = true;
+			     		}
 				    	 if (!top_banner_adView.isEnabled())
 				    	 	 top_banner_adView.setEnabled(true);
 				    	 
@@ -221,7 +231,11 @@ public class AdMobAds extends Framework
 
 				     @Override
 				     public void run()
-				     { 	
+				     {
+				     	if (!bottom_banner_adView_request_sended) {
+				     		bottom_banner_adView.loadAd(bottom_banner_adView_request);
+				     		bottom_banner_adView_request_sended = true;
+			     		}
 				    	 if (!bottom_banner_adView.isEnabled())
 				    		 bottom_banner_adView.setEnabled(true);
 				    	 
@@ -241,7 +255,11 @@ public class AdMobAds extends Framework
 
 				     @Override
 				     public void run()
-				     { 	
+				     {
+				     	if (!top_banner_adView_request_sended) {
+				     		top_banner_adView.loadAd(top_banner_adView_request);
+				     		top_banner_adView_request_sended = true;
+			     		}
 				    	 if (!top_banner_adView.isEnabled())
 				    	 	 top_banner_adView.setEnabled(true);
 				    	 
@@ -258,7 +276,11 @@ public class AdMobAds extends Framework
 
 				     @Override
 				     public void run()
-				     { 	
+				     {
+				     	 if (!bottom_banner_adView_request_sended) {
+				     		bottom_banner_adView.loadAd(bottom_banner_adView_request);
+				     		bottom_banner_adView_request_sended = true;
+			     		}
 				    	 if (!bottom_banner_adView.isEnabled())
 				    		 bottom_banner_adView.setEnabled(true);
 				    	 


### PR DESCRIPTION
Changing the request to be sent only the first time the ad is displayed, improved the time to show.
Send request with the ad hidden will discard the received and change update time to 60 sec, its how ad mob works. Keeping the adview hidden for too long also will trigger this condition.
