### PR TITLE
Fixed typo that was preventing videoWasViewedVungle from working on iOS.

### DIFF
--- a/SonarCocosHelperCPP/IOSHelper.m
+++ b/SonarCocosHelperCPP/IOSHelper.m
@@ -784,7 +784,7 @@ SCHEmptyProtocol
 {
     NSLog( viewInfo[@"completedView"] ? @"true" : @"false" );
 
-    [IOSResults rewardedVideoWasVuewedVungle:[[viewInfo objectForKey:@"completedView"] boolValue]];
+    [IOSResults videoWasViewedVungle:[[viewInfo objectForKey:@"completedView"] boolValue]];
 }
 
 -( void )vungleSDKwillShowAd


### PR DESCRIPTION
I was getting a crash when checking if a Vungle video had been watched. Turns out there was a typo in IOSHelper.m.
