### PR TITLE
Fixed: Google Analytics not passing "value" to SDK on iOS

### DIFF
--- a/SonarCocosHelperCPP/IOSCPPHelper.h
+++ b/SonarCocosHelperCPP/IOSCPPHelper.h
@@ -87,7 +87,7 @@ public:
 #if SCH_IS_GOOGLE_ANALYTICS_ENABLED == true
     static void setGAScreenName( __String screenName );
     static void setGADispatchInterval( int dispatchInterval );
-    static void sendGAEvent( __String category, __String action, __String label );
+    static void sendGAEvent( __String category, __String action, __String label, long value );
 #endif
 
 #if SCH_IS_ADCOLONY_ENABLED == true

--- a/SonarCocosHelperCPP/IOSCPPHelper.mm
+++ b/SonarCocosHelperCPP/IOSCPPHelper.mm
@@ -196,9 +196,9 @@ void IOSCPPHelper::setGADispatchInterval( int dispatchInterval )
     [[IOSHelper instance] setGADispatchInterval:dispatchInterval];
 }
 
-void IOSCPPHelper::sendGAEvent( __String category, __String action, __String label )
+void IOSCPPHelper::sendGAEvent( __String category, __String action, __String label, long value )
 {
-    [[IOSHelper instance] sendGAEvent:[NSString stringWithCString:category.getCString( ) encoding:NSUTF8StringEncoding]: [NSString stringWithCString:action.getCString( ) encoding:NSUTF8StringEncoding]: [NSString stringWithCString:label.getCString( ) encoding:NSUTF8StringEncoding]];
+    [[IOSHelper instance] sendGAEvent:[NSString stringWithCString:category.getCString( ) encoding:NSUTF8StringEncoding]: [NSString stringWithCString:action.getCString( ) encoding:NSUTF8StringEncoding]: [NSString stringWithCString:label.getCString( ) encoding:NSUTF8StringEncoding]: [NSNumber numberWithLong:(value)]];
 }
 #endif
 

--- a/SonarCocosHelperCPP/IOSHelper.h
+++ b/SonarCocosHelperCPP/IOSHelper.h
@@ -230,7 +230,7 @@ SCHEmptyProtocol
 #if SCH_IS_GOOGLE_ANALYTICS_ENABLED == true
 -( void )setGAScreenName:( NSString * )screenString;
 -( void )setGADispatchInterval:( int )dispatchInterval;
--( void )sendGAEvent:( NSString * ) category: ( NSString * ) action: ( NSString * ) label;
+-( void )sendGAEvent:( NSString * ) category: ( NSString * ) action: ( NSString * ) label: ( NSNumber * ) value;
 #endif
 
 #if SCH_IS_ADCOLONY_ENABLED == true

--- a/SonarCocosHelperCPP/IOSHelper.m
+++ b/SonarCocosHelperCPP/IOSHelper.m
@@ -735,12 +735,12 @@ SCHEmptyProtocol
 -( void )setGADispatchInterval:( int )dispatchInterval
 { [GAI sharedInstance].dispatchInterval = dispatchInterval; }
 
--( void )sendGAEvent:( NSString * ) category: ( NSString * ) action: ( NSString * ) label
+-( void )sendGAEvent:( NSString * ) category: ( NSString * ) action: ( NSString * ) label: ( NSNumber * ) value
 {
     [tracker send:[[GAIDictionaryBuilder createEventWithCategory:category     // Event category (required)
                                                           action:action  // Event action (required)
                                                            label:label          // Event label
-                                                           value:nil] build]];    // Event value
+                                                           value:value] build]];    // Event value
 }
 #endif
 

--- a/SonarCocosHelperCPP/SonarFrameworks.cpp
+++ b/SonarCocosHelperCPP/SonarFrameworks.cpp
@@ -546,7 +546,7 @@ void GoogleAnalytics::sendEvent( cocos2d::__String category, cocos2d::__String a
                                          value);
 #elif(CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
     #if SCH_IS_GOOGLE_ANALYTICS_ENABLED == true
-        IOSCPPHelper::sendGAEvent( category, action, label );
+        IOSCPPHelper::sendGAEvent( category, action, label, value );
     #endif
 #endif
 }


### PR DESCRIPTION
I found that GoogleAnalytics::sendEvent wasn't passing the "value" feild back to the Google Analytics SDK. This has been fixed and tested.
