### PR TITLE
Fixed: Issue with "Share" not creating an image on iOS

### DIFF
--- a/SonarCocosHelperCPP/IOSHelper.m
+++ b/SonarCocosHelperCPP/IOSHelper.m
@@ -384,8 +384,8 @@ SCHEmptyProtocol
 
 -( void )shareWithString:( NSString *) message: ( NSString * ) imagePath
 {
-    //UIImage *image = [[UIImage alloc] initWithData:[NSData dataWithContentsOfFile:imagePath]];
-    UIActivityViewController *activityVC = [[UIActivityViewController alloc] initWithActivityItems:@[message, imagePath] applicationActivities:nil];
+    UIImage *image = [UIImage imageNamed:imagePath];
+    UIActivityViewController *activityVC = [[UIActivityViewController alloc] initWithActivityItems:@[message, image] applicationActivities:nil];
     activityVC.excludedActivityTypes = @[UIActivityTypeAirDrop];
     
     // Finally present the view controller.


### PR DESCRIPTION
When providing SonarCocosHelper::IOS::Share with an image path, the message would display as "Hello world imagepath" instead of displaying the image.

This has been fixed and tested on iOS 7 and 9.
