### PR TITLE
Update GooglePlayServicesGameHelper.java

### DIFF
--- a/External Cocos Helper Android Frameworks/Frameworks/GooglePlayServices/GooglePlayServicesGameHelper.java
+++ b/External Cocos Helper Android Frameworks/Frameworks/GooglePlayServices/GooglePlayServicesGameHelper.java
@@ -29,7 +29,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
 
-import com.google.android.gms.appstate.AppStateManager;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.gms.common.api.Api.ApiOptions.NoOptions;


### PR DESCRIPTION
Google removes this package: (import) com.google.android.gms.appstate.AppStateManager;
In order to compile this project with the new version of Google Play Services Version : 27+
it's necessary to erase this lines.
