### PR TITLE
Update readme warning with google play services

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,4 +149,4 @@ Usage - Cocos2d-x JavaScript
 	
 # Google play services problems
 As far I know Google has release the new google play services revision 30.
-It removes the Google play services lib folder I will recomend you yo use the revision 29.
+It removes the Google play services lib folder I will recomend you to use the revision 29.

--- a/README.md
+++ b/README.md
@@ -146,3 +146,7 @@ Usage - Cocos2d-x JavaScript
 * AdColony
 	- Android : http://bit.ly/1C9FEuP
 	- iOS : http://bit.ly/1J2Vb1u
+	
+# Google play services problems
+As far I know Google has release the new google play services revision 30.
+It removes the Google play services lib folder I will recomend you yo use the revision 29.


### PR DESCRIPTION
Hello @SonarSystems  I was checking the framework google always make a mess, of course the problem with them are the 65k limit in the google play services, right now they separate the library in multiples SDK. I recommend use Play services revision 29 It was the lasted that work well (of course it will create a lot of methods in the app) We need help here I'm working on how can we update this.
