### PR TITLE
Android Admob Fix Crash Preload Interstitial

### DIFF
--- a/External Cocos Helper Android Frameworks/Frameworks/AdMob/AdMobAds.java
+++ b/External Cocos Helper Android Frameworks/Frameworks/AdMob/AdMobAds.java
@@ -42,8 +42,6 @@ public class AdMobAds extends Framework
 	private final int TOP = 1;
 	private final int BOTH = 2;
 	
-	public static native void FullscreenAdPreloaded(boolean result);
-	
 	private boolean preLoadCalled = false;
 	
 	public AdMobAds()
@@ -111,16 +109,11 @@ public class AdMobAds extends Framework
 	    {
 	          public void onAdLoaded()
 	          {
-	        	  if(preLoadCalled)
-	        	  {
-	        		  FullscreenAdPreloaded(true);
-	        	  }
-	        	  else
+	        	  if(!preLoadCalled)
 	        	  {
 	        		  LoadFullscreenAd();
+                      preLoadCalled = false;
 	        	  }
-	        	  
-	        	  preLoadCalled = false;
 	        	  
 	          }
 	    });
@@ -512,6 +505,7 @@ public class AdMobAds extends Framework
 			     {
 			    	 if(interstitial.isLoaded())
 			    		 interstitial.show();
+			 	     preLoadCalled = true;
 			     }
 		     });
 		}


### PR DESCRIPTION
Using a Admob preload interstitial in C++ in Adnroid, I get the following error:
`E/AndroidRuntime(31701): FATAL EXCEPTION: main`
`E/AndroidRuntime(31701): Process: com.LordNeznay.TheSculpin, PID: 31701`
`E/AndroidRuntime(31701): java.lang.UnsatisfiedLinkError: Native method not found: sonar.systems.frameworks.AdMob.AdMobAds.FullscreenAdPreloaded:(Z)V`
`E/AndroidRuntime(31701):   at sonar.systems.frameworks.AdMob.AdMobAds.FullscreenAdPreloaded(Native Method)`
`E/AndroidRuntime(31701):   at sonar.systems.frameworks.AdMob.AdMobAds$1.onAdLoaded(AdMobAds.java:116)`
`E/AndroidRuntime(31701):   at com.google.android.gms.ads.internal.client.zzc.onAdLoaded(Unknown Source)`
`E/AndroidRuntime(31701):   at com.google.android.gms.ads.internal.client.zzn$zza.onTransact(Unknown Source)`
`E/AndroidRuntime(31701):   at android.os.Binder.transact(Binder.java:361)`
`E/AndroidRuntime(31701):   at ua.c(:com.google.android.gms.DynamiteModulesA:152)`
`E/AndroidRuntime(31701):   at pm.p(:com.google.android.gms.DynamiteModulesA:857)`
`E/AndroidRuntime(31701):   at qn.p(:com.google.android.gms.DynamiteModulesA:411)`
`E/AndroidRuntime(31701):   at pm.b(:com.google.android.gms.DynamiteModulesA:466)`
`E/AndroidRuntime(31701):   at po.b(:com.google.android.gms.DynamiteModulesA:172)`
`E/AndroidRuntime(31701):   at alk.a(:com.google.android.gms.DynamiteModulesA:128)`
`E/AndroidRuntime(31701):   at alw.a(:com.google.android.gms.DynamiteModulesA:102)`
`E/AndroidRuntime(31701):   at alk.a(:com.google.android.gms.DynamiteModulesA:92)`
`E/AndroidRuntime(31701):   at avl.e(:com.google.android.gms.DynamiteModulesA:428)`
`E/AndroidRuntime(31701):   at avl.onPageFinished(:com.google.android.gms.DynamiteModulesA:387)`
`E/AndroidRuntime(31701):   at com.android.webview.chromium.WebViewContentsClientAdapter.onPageFinished(WebViewContentsClientAdapter.java:449)`
`E/AndroidRuntime(31701):   at com.android.org.chromium.android_webview.AwContentsClient$AwWebContentsObserver$1.run(AwContentsClient.java:73)`
`E/AndroidRuntime(31701):   at android.os.Handler.handleCallback(Handler.java:733)`
`E/AndroidRuntime(31701):   at android.os.Handler.dispatchMessage(Handler.java:95)`
`E/AndroidRuntime(31701):   at android.os.Looper.loop(Looper.java:146)`
`E/AndroidRuntime(31701):   at android.app.ActivityThread.main(ActivityThread.java:5593)`
`E/AndroidRuntime(31701):   at java.lang.reflect.Method.invokeNative(Native Method)`
`E/AndroidRuntime(31701):   at java.lang.reflect.Method.invoke(Method.java:515)`
`E/AndroidRuntime(31701):   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1283)`
`E/AndroidRuntime(31701):   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1099)`
`E/AndroidRuntime(31701):   at dalvik.system.NativeStart.main(Native Method)`

---

This error occurs after some time, after the function call `SonarCocosHelper::AdMob::preLoadFullscreenAd();`
As I understand, it happened at the time when the application receives a response to an interstitial ad request.
I found the following way to fix this error.
